### PR TITLE
Expose the uuid property for response set

### DIFF
--- a/NUSurveyorIOS/NUResponseSet.h
+++ b/NUSurveyorIOS/NUResponseSet.h
@@ -12,6 +12,7 @@
 
 @property (nonatomic, retain) NSMutableDictionary *dependencyGraph;
 @property (nonatomic, retain) NSMutableDictionary *dependencies;
+@property (nonatomic, retain) NSString* uuid;
 
 
 + (NUResponseSet *) newResponseSetForSurvey:(NSDictionary *)survey;

--- a/NUSurveyorIOS/NUResponseSet.m
+++ b/NUSurveyorIOS/NUResponseSet.m
@@ -11,7 +11,7 @@
 
 @implementation NUResponseSet
 
-@synthesize dependencyGraph, dependencies;
+@synthesize dependencyGraph, dependencies, uuid;
 
 // initializer
 + (NUResponseSet *) newResponseSetForSurvey:(NSDictionary *)survey {


### PR DESCRIPTION
Having an public identifier available for the response set is helpful and and a good idea, IMO.  In my application I use the uuid to retrieve the response set.
