### PR TITLE
Accept existing response set

### DIFF
--- a/NUSurveyorIOS/NUSurveyVC.m
+++ b/NUSurveyorIOS/NUSurveyVC.m
@@ -65,8 +65,10 @@
   SBJsonParser *parser = [[SBJsonParser alloc] init];  
   dict = [[parser objectWithString:responseString] retain];
     
-  // Create a new response set
-  self.responseSet = [NUResponseSet newResponseSetForSurvey:[dict objectForKey:@"survey"]];
+  // Create a new response set if one doesn't exist
+  if (responseSet == NULL) {
+    self.responseSet = [NUResponseSet newResponseSetForSurvey:[dict objectForKey:@"survey"]];
+  }
   
 	// Setup sectionController
   sectionController.responseSet = responseSet;


### PR DESCRIPTION
Currently the response set is always overwritten with a new one.  We should allow existing response sets to be used and modified.
