### PR TITLE
De-serialization fails when response group is null

### DIFF
--- a/NUSurveyor/Models/NUResponseSet.m
+++ b/NUSurveyor/Models/NUResponseSet.m
@@ -421,8 +421,8 @@
         [newResponse setValue:self forKey:@"responseSet"];
         [newResponse setValue:[response objectForKey:@"question_id"] forKey:@"question"];
         [newResponse setValue:[response objectForKey:@"answer_id"] forKey:@"answer"];
-        NSString* responseGroupRaw = [response objectForKey:@"response_group"];
-        NSNumber* responseGroup = responseGroupRaw ? [NSNumber numberWithInteger:[responseGroupRaw integerValue]] : NULL;
+        id responseGroupRaw = [response objectForKey:@"response_group"];
+        NSNumber* responseGroup = responseGroupRaw && ([NSNull null] != responseGroupRaw) ? [NSNumber numberWithInteger:[responseGroupRaw integerValue]] : NULL;
         [newResponse setValue:responseGroup forKey:@"responseGroup"];
         NSString* value = [response objectForKey:@"value"] == [NSNull null] ? nil : [response objectForKey:@"value"];
         [newResponse setValue:[value description] forKey:@"value"];

--- a/NUSurveyorTests/NUResponseSetTest.m
+++ b/NUSurveyorTests/NUResponseSetTest.m
@@ -117,6 +117,16 @@ NSDate* completedAt;
     STAssertEqualObjects([[[[rs valueForKey:@"responses"] objectEnumerator] nextObject] valueForKey:@"responseGroup"], [NSNumber numberWithInt:1], @"Should be 1");
 }
 
+- (void)testFromJsonWithNullResponseGroup {
+    NSString* jsonString = @"{\"uuid\":\"9af6d142-7fac-4ccb-9bca-58a05308a5a7\",\"survey_id\":\"94b3d750-fb63-4540-a1e2-dd7f88be9b4f\",\"created_at\":\"1970-02-04T05:15:30Z\",\"completed_at\":\"1990-03-06T07:21:42Z\",\"responses\":[{\"uuid\":\"07d72796-ebb2-4be2-91b9-68f5a30a0054\",\"answer_id\":\"9c788711-8373-44d7-b44b-754c31e596a9\",\"question_id\":\"376a501b-c32f-49de-b4d7-e28030a2ea94\",\"response_group\":null,\"created_at\":\"1970-02-04T05:15:30Z\",\"modified_at\":\"1990-03-06T07:21:42Z\"}]}";
+    
+    NSEntityDescription *entity = [[self.model entitiesByName] objectForKey:@"ResponseSet"];
+    NUResponseSet *rs = [[NUResponseSet alloc] initWithEntity:entity insertIntoManagedObjectContext:self.ctx];
+    [rs fromJson:jsonString];
+    
+    STAssertNil([[[[rs valueForKey:@"responses"] objectEnumerator] nextObject] valueForKey:@"responseGroup"], nil);
+}
+
 - (void) testFromJsonWithNullCompletedAt {
     NSString* jsonString = @"{\"uuid\":\"9af6d142-7fac-4ccb-9bca-58a05308a5a7\",\"survey_id\":\"94b3d750-fb63-4540-a1e2-dd7f88be9b4f\",\"created_at\":\"1970-02-04T05:15:30Z\",\"completed_at\":null,\"responses\":[]}";
     


### PR DESCRIPTION
When the responses JSON contain response groups with a null response group, de-serialization will fail because we aren't checking for NSNull.
