### PR TITLE
Dependency graph is overwritten in some scenarios

### DIFF
--- a/NUSurveyor.xcodeproj/project.pbxproj
+++ b/NUSurveyor.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0002A26816A5FC52004F3B5E /* NSDateFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0002A26716A5FC52004F3B5E /* NSDateFormatterTest.m */; };
+		0030EA2616C1FB2A00694153 /* double_dependency.json in Resources */ = {isa = PBXBuildFile; fileRef = 0030EA2516C1FB2A00694153 /* double_dependency.json */; };
 		005AA64B1521F04B00E67C10 /* NUResponseSetTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 006CE3B815214DB400DD32A2 /* NUResponseSetTest.m */; };
 		005AA64C1521F04B00E67C10 /* NUResponseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 005AA6491521676300E67C10 /* NUResponseTest.m */; };
 		005AA64F152208DE00E67C10 /* NUResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 005AA64D152208DE00E67C10 /* NUResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -209,6 +210,7 @@
 /* Begin PBXFileReference section */
 		0002A26616A5FC52004F3B5E /* NSDateFormatterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSDateFormatterTest.h; sourceTree = "<group>"; };
 		0002A26716A5FC52004F3B5E /* NSDateFormatterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSDateFormatterTest.m; sourceTree = "<group>"; };
+		0030EA2516C1FB2A00694153 /* double_dependency.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = double_dependency.json; sourceTree = "<group>"; };
 		005AA6481521676300E67C10 /* NUResponseTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NUResponseTest.h; sourceTree = "<group>"; };
 		005AA6491521676300E67C10 /* NUResponseTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NUResponseTest.m; sourceTree = "<group>"; };
 		005AA64D152208DE00E67C10 /* NUResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NUResponse.h; path = Models/NUResponse.h; sourceTree = "<group>"; };
@@ -653,6 +655,7 @@
 		3BD52ABB14C8B43500AB61E8 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				0030EA2516C1FB2A00694153 /* double_dependency.json */,
 				67DB499214D085CA009CC8C3 /* NUSurveyor.xcdatamodel */,
 				67DB496E14D07E6C009CC8C3 /* kitchen-sink-survey.json */,
 				67DB497014D080AC009CC8C3 /* test-dependency-survey.json */,
@@ -1278,6 +1281,7 @@
 				67DB497114D080AC009CC8C3 /* test-dependency-survey.json in Resources */,
 				3B8CF201151B91C600EA4148 /* test-birth-date-survey.json in Resources */,
 				3BF8D16B1694C92F00E1D438 /* screener.json in Resources */,
+				0030EA2616C1FB2A00694153 /* double_dependency.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NUSurveyor/Models/NUResponseSet.m
+++ b/NUSurveyor/Models/NUResponseSet.m
@@ -201,8 +201,8 @@
  }
  
  self.dependencyGraph = @{
-     @"<condition question/group uuid>": @[ 
-         @"<source question/group uuid>"
+     @"<question/group uuid>": @[
+         @"<dependent question/group uuid>"
      ]
  }
  */
@@ -229,11 +229,16 @@
 				if ([q objectForKey:@"dependency"] && [q objectForKey:@"uuid"] && [[q objectForKey:@"dependency"] objectForKey:@"conditions"]) {
 					[self.dependencies setObject:[q objectForKey:@"dependency"] forKey:[q objectForKey:@"uuid"]];
 					for (NSDictionary *condition in [[q objectForKey:@"dependency"] objectForKey:@"conditions"]) {
-						if ([self.dependencyGraph objectForKey:[condition objectForKey:@"question"]] && ![(NSMutableArray *)[self.dependencyGraph objectForKey:[condition objectForKey:@"question"]] containsObject:[q objectForKey:@"uuid"]]) {
-							[(NSMutableArray *)[self.dependencyGraph objectForKey:[condition objectForKey:@"question"]] addObject:[q objectForKey:@"uuid"]];
-						} else {
-							[self.dependencyGraph setObject:[NSMutableArray arrayWithObject:[q objectForKey:@"uuid"]] forKey:[condition objectForKey:@"question"]];
-						}
+                        NSString *key = [condition objectForKey:@"question"];
+                        NSString *val = [q objectForKey:@"uuid"];
+                        
+                        if (![self.dependencyGraph objectForKey:key]) {
+                            [self.dependencyGraph setObject:[NSMutableArray new] forKey:key];
+                        }
+                        
+                        if (![(NSMutableArray *)[self.dependencyGraph objectForKey:key] containsObject:val]) {
+                            [(NSMutableArray *)[self.dependencyGraph objectForKey:key] addObject:val];
+                        }
 					}
 				}
 			}

--- a/NUSurveyorTests/NUSurveyorTests.m
+++ b/NUSurveyorTests/NUSurveyorTests.m
@@ -277,4 +277,21 @@
   
 }
 
+- (void)testGenerateDependencyGraphWithTwoConditionsReferencingOneQuestion {
+    // JSON data
+    NSError *strError;
+    NSString *strPath = [self.bundle pathForResource:@"double_dependency" ofType:@"json"];
+    NSString *responseString = [NSString stringWithContentsOfFile:strPath encoding:NSUTF8StringEncoding error:&strError];
+    NSDictionary *dict = [responseString objectFromJSONString];
+
+    NSEntityDescription *entity = [[self.model entitiesByName] objectForKey:@"ResponseSet"];
+    NUResponseSet *rs = [[NUResponseSet alloc] initWithEntity:entity insertIntoManagedObjectContext:self.ctx];
+	[rs generateDependencyGraph:dict];
+
+    NSArray *actual = [rs.dependencyGraph valueForKey:@"9513a6b9-0fee-4146-a3d8-a3b6ad8af11b"];
+	NSArray *expect = @[@"e40e062e-898a-42b7-9c1f-81b8d80b6701", @"91efc704-0c80-40d3-b568-72159c93fb57"];
+
+    STAssertTrue([actual isEqualToArray:expect], @"Should be equal");
+}
+
 @end

--- a/NUSurveyorTests/double_dependency.json
+++ b/NUSurveyorTests/double_dependency.json
@@ -1,0 +1,87 @@
+{
+
+    "title": "Double Dependency",
+    "uuid": "cd759fed-f595-4ddf-9213-7582d67ffc95",
+    "sections": [
+        {
+            "title": "One",
+            "display_order": 0,
+            "questions_and_groups": [
+                {
+                    "uuid": "7945bbcd-9a3e-41ba-8ed5-66bc183ff25c",
+                    "text": "",
+                    "questions": [
+                        {
+                            "uuid": "9513a6b9-0fee-4146-a3d8-a3b6ad8af11b",
+                            "text": "Do you own a dog?",
+                            "reference_identifier": "dog",
+                            "pick": "one",
+                            "answers": [
+                                {
+                                    "uuid": "1bb5cb49-f158-4715-baf3-7381d7ea2d81",
+                                    "text": "Yes",
+                                    "reference_identifier": "yes"
+                                },
+                                {
+                                    "uuid": "b58874b9-9aa7-429f-95e9-065a30cf89fa",
+                                    "text": "No",
+                                    "reference_identifier": "no"
+                                }
+                            ]
+                        },
+                        {
+                            "uuid": "e40e062e-898a-42b7-9c1f-81b8d80b6701",
+                            "text": "What is his name?",
+                            "answers": [
+                                {
+                                    "uuid": "bdb2e78e-97e5-4134-a3f9-33ae23a7b50d",
+                                    "text": "",
+                                    "type": "string"
+                                }
+                            ],
+                            "dependency": {
+                                "rule": "A",
+                                "conditions": [
+                                    {
+                                        "rule_key": "A",
+                                        "operator": "==",
+                                        "question": "9513a6b9-0fee-4146-a3d8-a3b6ad8af11b",
+                                        "answer": "1bb5cb49-f158-4715-baf3-7381d7ea2d81"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "uuid": "91efc704-0c80-40d3-b568-72159c93fb57",
+                            "text": "How old is he?",
+                            "answers": [
+                                {
+                                    "uuid": "1a8d664a-af03-4440-b5da-b7b83e5e45db",
+                                    "text": "",
+                                    "type": "integer"
+                                }
+                            ],
+                            "dependency": {
+                                "rule": "A and B",
+                                "conditions": [
+                                    {
+                                        "rule_key": "A",
+                                        "operator": "count>0",
+                                        "question": "9513a6b9-0fee-4146-a3d8-a3b6ad8af11b"
+                                    },
+                                    {
+                                        "rule_key": "B",
+                                        "operator": "!=",
+                                        "question": "9513a6b9-0fee-4146-a3d8-a3b6ad8af11b",
+                                        "answer": "b58874b9-9aa7-429f-95e9-065a30cf89fa"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+
+}


### PR DESCRIPTION
The dependency graph is being overwritten when a question (within a group) has two conditions that reference the same question.

In the scenario below, both "What is his name?" and "How old is he?" should show when "Do you own a dog?" is "Yes". Only "How old is he?" shows though because the dependency graph is overwritten.

<pre>
survey "Double Dependency" do
  section "One" do
    group "" do
      q_dog "Do you own a dog?", :pick => :one
      a_yes "Yes"
      a_no  "No"

      q "What is his name?"
      a :string
      dependency :rule=>"A"
      condition_A :q_dog, "==", :a_yes

      q "How old is he?"
      a :integer
      dependency :rule=>"A and B"
      condition_A :q_dog, "count>0"
      condition_B :q_dog, "!=", :a_no
    end
  end
end
</pre>
