### PR TITLE
Switching sections while keyboard is showing causes errant responses to be created

### DIFF
--- a/Frank/features/textFieldResigns.feature
+++ b/Frank/features/textFieldResigns.feature
@@ -1,0 +1,20 @@
+Feature:
+  As an user
+  I want to take the textfield resigns test
+
+  Scenario:
+  Given I launch the app using iOS 5.1 and the ipad simulator
+    And the device is in landscape orientation
+    Then I wait for 2 seconds
+  When I touch the button marked "Inspect"
+    And I touch the button marked "loadComplexResponses"
+    Then I wait for 1 seconds
+  When I touch the table cell marked "I cannot tell"
+  When I use the keyboard to fill in the textfield marked "I cannot tell" with "hello" without hitting done
+    Then I wait for 1 seconds
+  When I touch the table cell marked "Any"
+    Then the cell marked "tricyclic" should be unchecked
+    Then I wait for 1 seconds
+  When I touch the button marked "Inspect"
+    Then I should see a "1 response" label
+    

--- a/NUSurveyor.xcodeproj/project.pbxproj
+++ b/NUSurveyor.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		00D61CA716B02E7400565A8B /* shoes.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = shoes.json; sourceTree = "<group>"; };
 		00DD775416A74CBA00D78EBE /* animals.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = animals.json; sourceTree = "<group>"; };
 		00DD775616A74E1900D78EBE /* complex_dependencies.feature */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = complex_dependencies.feature; sourceTree = "<group>"; };
+		16274D3C16C45E5100DBBAFC /* textFieldResigns.feature */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = textFieldResigns.feature; sourceTree = "<group>"; };
 		16F5F2B116C03DDC007F0AD9 /* dependencies_toolbox.feature */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = dependencies_toolbox.feature; sourceTree = "<group>"; };
 		16F5F2B216C056C5007F0AD9 /* dependencyToolbox.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = dependencyToolbox.json; sourceTree = "<group>"; };
 		3B08678E14FED8C100D43E02 /* group_dependency.feature */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = group_dependency.feature; sourceTree = "<group>"; };
@@ -1023,6 +1024,7 @@
 				16F5F2B116C03DDC007F0AD9 /* dependencies_toolbox.feature */,
 				3BC61A9615211EF000A8C20C /* complex_responses.feature */,
 				3BF9710D1524FE08008D3A9A /* mustache.feature */,
+				16274D3C16C45E5100DBBAFC /* textFieldResigns.feature */,
 				67DB4A0914D09EB6009CC8C3 /* step_definitions */,
 				67DB4A0B14D09EB6009CC8C3 /* support */,
 				00DD775616A74E1900D78EBE /* complex_dependencies.feature */,

--- a/NUSurveyor/Controllers/NUSectionTVC.m
+++ b/NUSurveyor/Controllers/NUSectionTVC.m
@@ -149,9 +149,8 @@
   self.pageControl.frame = CGRectMake(0.0, 19.0, self.view.frame.size.width, 36.0);
 	self.pageControl.userInteractionEnabled = NO;
 	[self.navigationController.view addSubview:self.pageControl];
-  self.tableView.accessibilityLabel = @"sectionTableView"; 
+  self.tableView.accessibilityLabel = @"sectionTableView";
 	
-
   // Swipe gesture recognizers
   // A left to right swipe is now used to bring up the master table view, so these conflict.
   //  UISwipeGestureRecognizer *r = [[UISwipeGestureRecognizer alloc] initWithTarget:self.delegate action:@selector(prevSection)];
@@ -208,7 +207,7 @@
 }
 
 - (void)createRows
-{ 
+{
   
   [self createHeader];
   [self createFooter];
@@ -381,6 +380,7 @@
     [self.cursorView resignFirstResponder];
     self.cursorView = nil;
   }
+    [tableView deselectRowAtIndexPath:indexPath animated:NO];
 }
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section{
 	NSString *title = [self tableView:tableView titleForHeaderInSection:section];

--- a/NUSurveyor/Controllers/NUSurveyTVC.m
+++ b/NUSurveyor/Controllers/NUSurveyTVC.m
@@ -215,7 +215,8 @@
      // Pass the selected object to the new view controller.
      [self.navigationController pushViewController:detailViewController animated:YES];
      */
-	[self showSection:indexPath.row];
+    [[NSNotificationCenter defaultCenter] postNotificationName:MASTER_VC_DID_SELECT_ROW object:nil];
+    [self showSection:indexPath.row];
 }
 
 #pragma mark - Section navigation

--- a/NUSurveyor/NUConstants.h
+++ b/NUSurveyor/NUConstants.h
@@ -10,3 +10,5 @@
 #define RGBA(r, g, b, a)	[UIColor colorWithRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:a]
 #define NS_YES [NSNumber numberWithBool:YES]
 #define NS_NO  [NSNumber numberWithBool:NO]
+
+#define MASTER_VC_DID_SELECT_ROW @"MasterViewControllerDidSelectRow"

--- a/NUSurveyor/Views/NUAnyStringOrNumberCell.m
+++ b/NUSurveyor/Views/NUAnyStringOrNumberCell.m
@@ -11,6 +11,7 @@
 
 @interface NUAnyStringOrNumberCell()
 - (void) resetContent;
+-(void)cellSectionWasDeselected:(NSNotification *)note;
 @end
 @implementation NUAnyStringOrNumberCell
 
@@ -58,6 +59,9 @@
     self.postLabel.backgroundColor = groupedBackgroundColor;;
     self.postLabel.autoresizingMask = UIViewAutoresizingNone;
     [self.contentView addSubview:self.postLabel];
+      
+      //Notification
+      [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(cellSectionWasDeselected:) name:MASTER_VC_DID_SELECT_ROW object:nil];      
   }
   return self;
 }
@@ -67,6 +71,10 @@
   [super setSelected:selected animated:animated];
   
   // Configure the view for the selected state
+}
+
+-(void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:MASTER_VC_DID_SELECT_ROW object:nil];
 }
 
 #pragma mark - NUCell
@@ -177,6 +185,12 @@
                                       self.textField.frame.size.height);
   }
   
+}
+
+#pragma mark notification
+
+-(void)cellSectionWasDeselected:(NSNotification *)note {
+    [self.textField resignFirstResponder];
 }
 
 

--- a/NUSurveyor/Views/NUNoneCell.m
+++ b/NUSurveyor/Views/NUNoneCell.m
@@ -11,6 +11,7 @@
 
 @interface NUNoneCell()
 - (void) resetContent;
+-(void)cellSectionWasDeselected:(NSNotification *)note;
 @end
 @implementation NUNoneCell
 @synthesize textField = _textField, label = _label, postLabel = _postLabel, sectionTVC = _sectionTVC;
@@ -56,6 +57,9 @@
       self.postLabel.backgroundColor = groupedBackgroundColor;;
       self.postLabel.autoresizingMask = UIViewAutoresizingNone;
       [self.contentView addSubview:self.postLabel];
+        
+        //Notification
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(cellSectionWasDeselected:) name:MASTER_VC_DID_SELECT_ROW object:nil];
     }
     return self;
 }
@@ -65,6 +69,10 @@
     [super setSelected:selected animated:animated];
 
     // Configure the view for the selected state
+}
+
+-(void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:MASTER_VC_DID_SELECT_ROW object:nil];
 }
 
 #pragma mark - NUCell
@@ -156,6 +164,12 @@
                                  self.postLabel.frame.size.width + self.textField.frame.size.width, 
                                  self.textField.frame.size.height);
   }
-  
 }
+
+#pragma mark notification
+
+-(void)cellSectionWasDeselected:(NSNotification *)note {
+    [self.textField resignFirstResponder];
+}
+
 @end

--- a/NUSurveyor/Views/NUNoneTextCell.m
+++ b/NUSurveyor/Views/NUNoneTextCell.m
@@ -8,6 +8,10 @@
 
 #import "NUNoneTextCell.h"
 
+@interface NUNoneTextCell()
+-(void)cellSectionWasDeselected:(NSNotification *)note;
+@end
+
 @implementation NUNoneTextCell
 @synthesize textView = _textView, label = _label, sectionTVC = _sectionTVC;
 
@@ -62,6 +66,9 @@
       self.label.shadowOffset = CGSizeMake(0, 1);
       
       [self.contentView addSubview:self.label];
+        
+        //Notification
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(cellSectionWasDeselected:) name:MASTER_VC_DID_SELECT_ROW object:nil];
     }
     return self;
 }
@@ -71,6 +78,10 @@
     [super setSelected:selected animated:animated];
 
     // Configure the view for the selected state
+}
+
+-(void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:MASTER_VC_DID_SELECT_ROW object:nil];
 }
 
 #pragma mark - NUCell
@@ -109,6 +120,12 @@
 - (void)selectedinTableView:(UITableView *)tableView indexPath:(NSIndexPath *)indexPath{
   [self.textView becomeFirstResponder];
   // Don't need deselect for: UITableViewCellSelectionStyleNone
+}
+
+#pragma mark notification
+
+-(void)cellSectionWasDeselected:(NSNotification *)note {
+    [self.textView resignFirstResponder];
 }
 
 @end

--- a/NUSurveyor/Views/NUOneStringOrNumberCell.m
+++ b/NUSurveyor/Views/NUOneStringOrNumberCell.m
@@ -12,6 +12,7 @@
 
 @interface NUOneStringOrNumberCell()
 - (void) resetContent;
+-(void)cellSectionWasDeselected:(NSNotification *)note;
 @end
 @implementation NUOneStringOrNumberCell
 
@@ -59,6 +60,9 @@
     self.postLabel.backgroundColor = groupedBackgroundColor;;
     self.postLabel.autoresizingMask = UIViewAutoresizingNone;
     [self.contentView addSubview:self.postLabel];
+      
+    //Notification
+      [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(cellSectionWasDeselected:) name:MASTER_VC_DID_SELECT_ROW object:nil];
   }
   return self;
 }
@@ -68,6 +72,10 @@
   [super setSelected:selected animated:animated];
   
   // Configure the view for the selected state
+}
+
+-(void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:MASTER_VC_DID_SELECT_ROW object:nil];
 }
 
 #pragma mark - NUCell
@@ -187,6 +195,12 @@
                                       self.textField.frame.size.height);
   }
   
+}
+
+#pragma mark notification
+
+-(void)cellSectionWasDeselected:(NSNotification *)note {
+    [self.textField resignFirstResponder];
 }
 
 @end


### PR DESCRIPTION
The issue was caused by the UITableView subclass (NUSectionTVC) being refreshed before a cell's textField had resigned it's first responder. The result was that when the tableView was refreshed, the textField's didFinishEditing was being called which in turn called a method for an empty response to be created and saved to the persistent store.

The issue was resolved by creating a notification to alert any open textFields to resign it's first responder before the tableView was refreshed. A test was written to confirm that this worked.
