### PR TITLE
Fixed issue where 'is_exclusive' is being used by surveyor but not surveyor-ios on answers. Bug #3464

### DIFF
--- a/NUSurveyor/Controllers/NUSectionTVC.m
+++ b/NUSurveyor/Controllers/NUSectionTVC.m
@@ -841,7 +841,7 @@
     };
     
     NSDictionary *answerDictionary = answerDictionaryForIndexPath(idx);
-    if ([answerDictionary[@"exclusive"] isEqualToNumber:@(YES)]) {  //if the cell is exclusive…
+    if ([answerDictionary[@"exclusive"] isEqualToNumber:@(YES)] || [answerDictionary[@"is_exclusive"] isEqualToNumber:@(YES)]) {  //if the cell is exclusive…
         NSUInteger numberOfCells = [self.tableView numberOfRowsInSection:idx.section];
         for (int i = 0; i < numberOfCells ; i++) {
             if (i != idx.row) {
@@ -856,8 +856,8 @@
         for (int i = 0; i < numberOfCells ; i++) {
             if (i != idx.row) {
                 NSIndexPath *deselectIndexPath = [NSIndexPath indexPathForRow:i inSection:idx.section];
-                NSDictionary *answerDictionary = answerDictionaryForIndexPath(deselectIndexPath);
-                if ([answerDictionary[@"exclusive"] isEqualToNumber:@(YES)]) {
+                NSDictionary *subAnswerDictionary = answerDictionaryForIndexPath(deselectIndexPath);
+                if ([subAnswerDictionary[@"exclusive"] isEqualToNumber:@(YES)] || [subAnswerDictionary[@"is_exclusive"] isEqualToNumber:@(YES)]) {
                     NSIndexPath *deselectIndexPath = [NSIndexPath indexPathForRow:i inSection:idx.section];
                     deselectAnswerAtIndexPath(deselectIndexPath);
                 }


### PR DESCRIPTION
Based on the surveys in the surveyor_ios project, the answer's exclusivity was based on the key "exclusive". It turns out that "exclusive" and "is_exclusive" are used in tandem due to a bug with surveyor. In order to safeguard against this issue, surveyor_ios now checks against both.
