### PR TITLE
Fixed issue where exclusiveCheck function would crash if function would return nil.

### DIFF
--- a/NUSurveyor/Controllers/NUSectionTVC.m
+++ b/NUSurveyor/Controllers/NUSectionTVC.m
@@ -822,6 +822,7 @@
     NSDictionary *(^answerDictionaryForIndexPath)(NSIndexPath *) = ^(NSIndexPath *indexPath) {
         NSString *qid = [[weakSelf idsForIndexPath:indexPath] objectForKey:@"qid"];
         NSString *aid = [[weakSelf idsForIndexPath:indexPath] objectForKey:@"aid"];
+        if (aid == nil || qid == nil) { return @{}; }
         NSDictionary *questionDictionary = [weakSelf questionOrGroupWithUUID:qid];
         NSDictionary *answerDictionary = [[questionDictionary[@"answers"] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"uuid MATCHES %@", aid]] lastObject];
         return answerDictionary;


### PR DESCRIPTION
There was an outlying chance that when checking if the cell's answer was exclusive, the result would be nil causing a rare crash. This returns an empty dictionary if no match.
